### PR TITLE
Distortions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples/flatfield_sim.png
 examples/flatfield.png
 examples/weightmap.png
 *.mat
+testing/*

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -18,9 +18,9 @@ version = "0.8.2"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "195c5505521008abea5aee4f96930717958eac6f"
+git-tree-sha1 = "0310e08cb19f5da31d08341c6120c047598f5b9c"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.4.0"
+version = "3.5.0"
 
 [[deps.ArgCheck]]
 git-tree-sha1 = "a3a402a35a2f7e0b87828ccabbd5ebfbebe356b4"
@@ -102,15 +102,15 @@ version = "0.2.2"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "e7ff6cadf743c098e08fca25c91103ee4303c9bb"
+git-tree-sha1 = "c6d890a52d2c4d55d326439580c3b8d0875a77d9"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.6"
+version = "1.15.7"
 
 [[deps.ChangesOfVariables]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
-git-tree-sha1 = "38f7a08f19d8810338d4f5085211c7dfa5d5bdd8"
+git-tree-sha1 = "844b061c104c408b24537482469400af6075aae4"
 uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
-version = "0.1.4"
+version = "0.1.5"
 
 [[deps.Clustering]]
 deps = ["Distances", "LinearAlgebra", "NearestNeighbors", "Printf", "Random", "SparseArrays", "Statistics", "StatsBase"]
@@ -120,9 +120,9 @@ version = "0.14.3"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
+git-tree-sha1 = "9c209fb7536406834aa938fb149964b985de6c83"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.0"
+version = "0.7.1"
 
 [[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -149,9 +149,9 @@ version = "1.0.2"
 
 [[deps.Compat]]
 deps = ["Dates", "LinearAlgebra", "UUIDs"]
-git-tree-sha1 = "00a2cccc7f098ff3b66806862d275ca3db9e6e5a"
+git-tree-sha1 = "61fdd77467a5c3ad071ef8277ac6bd6af7dd4c04"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.5.0"
+version = "4.6.0"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -294,9 +294,9 @@ uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[deps.Ghostscript_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "78e2c69783c9753a91cdae88a8d432be85a2ab5e"
+git-tree-sha1 = "71061d79c8d92172ece80e567c0de45a2bb9d989"
 uuid = "61579ee1-b43e-5ca0-a5da-69d92c66a64b"
-version = "9.55.0+0"
+version = "9.55.0+3"
 
 [[deps.Graphics]]
 deps = ["Colors", "LinearAlgebra", "NaNMath"]
@@ -496,9 +496,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "Printf", "Reexport", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "ec8a9c9f0ecb1c687e34c1fda2699de4d054672a"
+git-tree-sha1 = "c3244ef42b7d4508c638339df1bdbf4353e144db"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.29"
+version = "0.4.30"
 
 [[deps.JLLWrappers]]
 deps = ["Preferences"]
@@ -508,9 +508,9 @@ version = "1.4.1"
 
 [[deps.JpegTurbo]]
 deps = ["CEnum", "FileIO", "ImageCore", "JpegTurbo_jll", "TOML"]
-git-tree-sha1 = "a77b273f1ddec645d1b7c4fd5fb98c8f90ad10a5"
+git-tree-sha1 = "106b6aa272f294ba47e96bd3acbabdc0407b5c60"
 uuid = "b835a17e-a41a-41e7-81f0-2f016b05efe0"
-version = "0.1.1"
+version = "0.1.2"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -573,9 +573,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "946607f84feb96220f480e0422d3484c49c00239"
+git-tree-sha1 = "680e733c3a0a9cea9e935c8c2184aea6a63fa0b5"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.19"
+version = "0.3.21"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -625,9 +625,9 @@ version = "0.4.4"
 
 [[deps.MetaGraphs]]
 deps = ["Graphs", "JLD2", "Random"]
-git-tree-sha1 = "2af69ff3c024d13bde52b34a2a7d6887d4e7b438"
+git-tree-sha1 = "1130dbe1d5276cb656f6e1094ce97466ed700e5a"
 uuid = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
-version = "0.7.1"
+version = "0.7.2"
 
 [[deps.MicroCollections]]
 deps = ["BangBang", "InitialValues", "Setfield"]
@@ -696,9 +696,9 @@ version = "1.2.0"
 
 [[deps.OffsetArrays]]
 deps = ["Adapt"]
-git-tree-sha1 = "f71d8950b724e9ff6110fc948dff5a329f901d64"
+git-tree-sha1 = "82d7c9e310fe55aa54996e6f7f94674e2a38fcb4"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.8"
+version = "1.12.9"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
@@ -885,9 +885,9 @@ version = "0.9.4"
 
 [[deps.SimpleWeightedGraphs]]
 deps = ["Graphs", "LinearAlgebra", "Markdown", "SparseArrays", "Test"]
-git-tree-sha1 = "a6f404cc44d3d3b28c793ec0eb59af709d827e4e"
+git-tree-sha1 = "a8d28ad975506694d59ac2f351e29243065c5c52"
 uuid = "47aef6b3-ad0c-573a-a1e2-d07658019622"
-version = "1.2.1"
+version = "1.2.2"
 
 [[deps.Sixel]]
 deps = ["Dates", "FileIO", "ImageCore", "IndirectArrays", "OffsetArrays", "REPL", "libsixel_jll"]
@@ -896,9 +896,10 @@ uuid = "45858cf5-a6b0-47a3-bbea-62219f50df47"
 version = "0.1.2"
 
 [[deps.SnoopPrecompile]]
-git-tree-sha1 = "f604441450a3c0569830946e5b33b78c928e1a85"
+deps = ["Preferences"]
+git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
 uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
-version = "1.0.1"
+version = "1.0.3"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"

--- a/src/model.jl
+++ b/src/model.jl
@@ -57,11 +57,15 @@ function createForwardmodel(
 end
 
 """
-    generate_model(psfs::AbstractArray{T,3}, rank::Int[, ref_image_index::Int]; reduce=false)
+    generate_model(psfs::AbstractArray{T,N}, rank::Int[, ref_image_index::Int]; reduce=false, itp_method=Shepard(), positions=nothing) where {T,N}
 
 Construct the forward model using the PSFs in `psfs` employing an interpolation
  of the first `rank` components calculated from a SVD. If `reduce==true`, a 3D volume will be
  mapped to a 2D image by summation over the z-axis.
+
+The interpolation of the coefficients of the eigenimages is done using the `itp_method`.
+
+If the PSF locations differ from their center of mass, `positions` can be supplied as an array of size `(N-1, size(psfs,N))`.
 
 `ref_image_index` is the index of the reference PSF along dim 3 of `psfs`. 
  Default: `ref_image_index = size(psfs)[end] ÷ 2 + 1`
@@ -119,9 +123,18 @@ function generate_model(
     return model
 end
 
+"""    generate_model(psfs_path::String, psf_name::String, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard(), positions=nothing)
+
+Alternatively, a path to a mat or hdf5 file `psfs_path` can be given, where the PSFs array can be accessed with the key `psf_name`.
+
+`positions` can be given as an array or as a string. If `positions` is a String, it will be used as a key to load the positions array from `psfs_path`.
+"""
 function generate_model(
     psfs_path::String, psf_name::String, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard(), positions=nothing
 )
     psfs = read_psfs(psfs_path, psf_name)
+    if positions isa AbstractString
+        positions = read_psfs(psfs_path, positions)
+    end
     return generate_model(psfs, rank, ref_image_index; reduce=reduce, itp_method=itp_method, positions=positions)
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -67,7 +67,7 @@ Construct the forward model using the PSFs in `psfs` employing an interpolation
  Default: `ref_image_index = size(psfs)[end] ÷ 2 + 1`
 """
 function generate_model(
-    psfs::AbstractArray{T,N}, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard(), shifts=nothing
+    psfs::AbstractArray{T,N}, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard(), positions=nothing
 ) where {T,N}
     if ref_image_index == -1
         # Assume reference image is in the middle
@@ -79,13 +79,13 @@ function generate_model(
         @info "reduce is true, but dimensions are 2, so reduce is ignored"
         my_reduce = false
     end
-    if isnothing(shifts)
+    if isnothing(positions)
         psfs_reg, shifts = SpatiallyVaryingConvolution.registerPSFs(
         psfs, collect(selectdim(psfs, N, ref_image_index))
         )
     else
         center_pos = size(psfs)[1:(end-1)] .÷2 .+ 1
-        shifts = center_pos .- shifts
+        shifts = center_pos .- positions
         psfs_reg = shift_psfs(psfs, shifts)
     end
     comps, weights = decompose(psfs_reg, rank)
@@ -120,8 +120,8 @@ function generate_model(
 end
 
 function generate_model(
-    psfs_path::String, psf_name::String, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard(), shifts=nothing
+    psfs_path::String, psf_name::String, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard(), positions=nothing
 )
     psfs = read_psfs(psfs_path, psf_name)
-    return generate_model(psfs, rank, ref_image_index; reduce=reduce, itp_method=itp_method, shifts=shifts)
+    return generate_model(psfs, rank, ref_image_index; reduce=reduce, itp_method=itp_method, positions=positions)
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -67,7 +67,7 @@ Construct the forward model using the PSFs in `psfs` employing an interpolation
  Default: `ref_image_index = size(psfs)[end] ÷ 2 + 1`
 """
 function generate_model(
-    psfs::AbstractArray{T,N}, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard()
+    psfs::AbstractArray{T,N}, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard(), shifts=nothing
 ) where {T,N}
     if ref_image_index == -1
         # Assume reference image is in the middle
@@ -79,9 +79,15 @@ function generate_model(
         @info "reduce is true, but dimensions are 2, so reduce is ignored"
         my_reduce = false
     end
-    psfs_reg, shifts = SpatiallyVaryingConvolution.registerPSFs(
+    if isnothing(shifts)
+        psfs_reg, shifts = SpatiallyVaryingConvolution.registerPSFs(
         psfs, collect(selectdim(psfs, N, ref_image_index))
-    )
+        )
+    else
+        center_pos = size(psfs)[1:(end-1)] .÷2 .+ 1
+        shifts = center_pos .- shifts
+        psfs_reg = shift_psfs(psfs, shifts)
+    end
     comps, weights = decompose(psfs_reg, rank)
     if N == 4 && any(shifts[3, :] .!= zero(Int))
         weights_interp = interpolateWeights(weights, size(comps)[1:3], shifts; itp_method=itp_method)
@@ -114,8 +120,8 @@ function generate_model(
 end
 
 function generate_model(
-    psfs_path::String, psf_name::String, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard()
+    psfs_path::String, psf_name::String, rank::Int, ref_image_index::Int=-1; reduce=false, itp_method=Shepard(), shifts=nothing
 )
     psfs = read_psfs(psfs_path, psf_name)
-    return generate_model(psfs, rank, ref_image_index; reduce=reduce, itp_method=itp_method)
+    return generate_model(psfs, rank, ref_image_index; reduce=reduce, itp_method=itp_method, shifts=shifts)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -98,6 +98,36 @@ function _linshift!(
     end
 end
 
+
+"""    shift_psfs(stack::AbstractArray{T,N}, shift_indices, good_indices=1:size(stack, N)) where {T,N}
+
+Shift each measurement image/volume in `stack` by the x-y-z-shifts given in `shift_indices` (`size(shift_indices)=(N, size(stack, N))`).
+
+Only the measurements indexed by `good_indices` are considered.
+"""
+function shift_psfs(stack::AbstractArray{T,N}, shift_indices, good_indices=1:size(stack, N)) where {T,N}
+    # Output destination
+    yi_reg = similar(stack)
+    # Temporary shifting destination
+    im_reg = similar(stack, size(stack)[1:(end - 1)])
+    #Populate yi_reg
+    # In 3D, with z-shift, do a linear shift (without wrap-around)
+    if N == 4 && maximum(abs.(shift_indices[3, :])) > zero(eltype(shift_indices))
+        for ind in good_indices
+            selected_stack = selectdim(stack, N, ind)
+            _linshift!(im_reg, selected_stack, shift_indices[:, ind])
+            selectdim(yi_reg, N, ind) .= im_reg
+        end
+    else
+        # Else, a circshift should be good enough
+        for ind in good_indices
+            circshift!(im_reg, selectdim(stack, N, ind), shift_indices[:, ind])
+            selectdim(yi_reg, N, ind) .= im_reg
+        end
+    end
+    return yi_reg
+end
+
 function _prepare_buffers_forward(H::AbstractArray{T,N}, size_padded_weights) where {T,N}
     ND = ndims(H)
     # x is padded in first N-1 dimension to be as big as padded_weights

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,6 +27,8 @@ function read_psfs(path::String, key::String)
     if haskey(file, key)
         psfs = read(file, key)
         return psfs
+    else
+        @warn "Key $key not found in $(path)!"
     end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -53,7 +53,9 @@ end
         savePSFs(random_2, joinpath(path, h5_filename), h5_key)
         @test random_1 == read_psfs(joinpath(path, mat_filename), mat_key)
         @test random_2 == read_psfs(joinpath(path, h5_filename), h5_key)
+        @info "The following warnings are part of testing"
         @test isnothing(read_psfs(joinpath(path, mat_filename), h5_key))
+        @test_logs (:warn,"Key $(h5_key) not found in $(joinpath(path, mat_filename))!") read_psfs(joinpath(path, mat_filename), h5_key)
     end
 
     @testset "Test construction wrapper" begin
@@ -70,6 +72,24 @@ end
         img1 = model1(test_img)
         img2 = model2(test_img)
         @test img1 ≈ img2
+        # Test if loading with string tries to get the positions from the PSF file. If it failf, it displays a warning
+        positions_key = "positions"
+        @test_logs (:warn, "Key $positions_key not found in $(filepath)!") generate_model(filepath, psfs_key, rank; positions=positions_key)
+        # Now try the model with user supplied positions
+        # There are three ways to construct a model with user supplied poitiosn, so check for equivalence of these ways
+        positions = rand(1:200, 2, 9)
+        path = mktempdir()
+        filepath = joinpath(path, filename)
+        matwrite(filepath, Dict(psfs_key=>psfs, positions_key=>positions))
+        model1 = generate_model(psfs, rank; positions=positions)
+        model2 = generate_model(filepath, psfs_key, rank; positions=positions_key)
+        model3 = generate_model(filepath, psfs_key, rank; positions=positions)
+        test_img = rand(Float32, 200, 201)
+        img1 = model1(test_img)
+        img2 = model2(test_img)
+        img3 = model3(test_img)
+        @test img1 ≈ img2
+        @test img2 ≈ img3
     end
 
     @testset "_linshift!" begin


### PR DESCRIPTION
Accept user supplied positions of the PSFs.
If PSF positions are supplied, the package doesn't need to rely on autocorrelation to guess the PSF positions. This way, modelling geometric distortions of the system is possible.

Changes:
- Add `positions` keyword to `generate_model`. This should either be an array with the positions of the PSFs (size ndims(PSF)-1 x nr_of_psfs) or a key string, if the positions are stored together with the PSFs in a single MAT or HDF5 file.
- If `positions` are supplied, skip `register_PSFs` and shift the PSF array directly according to `positions`
- Warn user if a key is not found in the MAT/HDF5 file